### PR TITLE
Added ability to open URLs without netrw

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ However, you can customise the default behaviour using the `setup` function:
 ```lua
 require("urlview").setup({
   title = "URLs: ", -- prompt title
+  use_netrw = true, -- use netrw to open urls, if false use xdg-open/open system command
   debug = true, -- logs user errors
 })
 

--- a/lua/urlview/config.lua
+++ b/lua/urlview/config.lua
@@ -1,6 +1,7 @@
 -- Default config
 local config = {
 	title = "URLs: ", -- prompt title
+	use_netrw = true, -- use netrw to open urls, if false use xdg-open/open system command
 	debug = true, -- logs user errors
 }
 

--- a/lua/urlview/utils.lua
+++ b/lua/urlview/utils.lua
@@ -44,7 +44,23 @@ end
 --- Opens the url in the browser
 ---@param url string
 function M.navigate_url(url)
-	vim.cmd("call netrw#BrowseX('" .. url .. "',netrw#CheckIfRemote())")
+	if config.use_netrw then
+		vim.cmd("call netrw#BrowseX('" .. url .. "',netrw#CheckIfRemote())")
+	else
+		-- supports MacOS, Linux, and FreeBSD
+		local cmd = nil
+		if vim.fn.has "mac" == 1 then -- MacOS
+			cmd = "open "
+		elseif vim.fn.has "linux" == 1 or vim.fn.has "bsd" then -- Linux and FreeBSD
+			cmd = "xdg-open "
+		end
+
+		if cmd then
+			os.execute(cmd .. vim.fn.shellescape(url, 1))
+		else
+			vim.notify("Unsupported OS for opening url from the command line", vim.log.levels.DEBUG)
+		end
+	end
 end
 
 --- Determines whether to accept the current value or use a fallback value


### PR DESCRIPTION
Thanks for the awesome plugin! I just put together a small suggestion that allows people like myself who turn `netrw` off in their config to still be able to use this plugin. It uses the `open` (MacOS) or `xdg-open` (Linux/FreeBSD) system command to launch the URLs in the default browser for `http`/`https` links. Feel free to disregard though if you're not interested in supporting these, this is just my preferred way of launching URLs 🙂

P.S. - please do not mind the force-pushes, I kept forgetting that my Neovim auto-formats Lua code differently than the standard that this plugin currently uses 🙃 