### PR TITLE
refactor!: renamed default_picker "default" to "native" (vim.ui.select)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ require("urlview").setup({
   -- Prompt title (`<context> <default_title>`, e.g. `Buffer Links:`)
   default_title = "Links:",
   -- Default picker to display links with
-  -- Options: "default" (vim.ui.select) or "telescope"
-  default_picker = "default",
+  -- Options: "native" (vim.ui.select) or "telescope"
+  default_picker = "native",
   -- Set the default protocol for us to prefix URLs with if they don't start with http/https
   default_prefix = "https://",
   -- Command or method to open links with
@@ -75,7 +75,7 @@ require("urlview").setup({
 
 ## 🎨 Pickers
 
-### ✔️ Default (vim.ui.select)
+### ✔️ Native (vim.ui.select)
 
 You can customise the appearance of `vim.ui.select` with plugins such as [dressing.nvim](https://github.com/stevearc/dressing.nvim). In the demo above, I used the [telescope](https://github.com/nvim-telescope/telescope.nvim) option, which further allows me to filter and fuzzy search through my entries.
 

--- a/lua/urlview/config.lua
+++ b/lua/urlview/config.lua
@@ -4,8 +4,8 @@ local default_config = {
   -- Prompt title (`<context> <default_title>`, e.g. `Buffer Links:`)
   default_title = "Links:",
   -- Default picker to display links with
-  -- Options: "default" (vim.ui.select) or "telescope"
-  default_picker = "default",
+  -- Options: "native" (vim.ui.select) or "telescope"
+  default_picker = "native",
   -- Set the default protocol for us to prefix URLs with if they don't start with http/https
   default_prefix = "https://",
   -- Command or method to open links with

--- a/lua/urlview/pickers.lua
+++ b/lua/urlview/pickers.lua
@@ -5,7 +5,7 @@ local utils = require("urlview.utils")
 --- Displays items using the vim.ui.select picker
 ---@param items table (list) of strings
 ---@param opts table (map) of options
-function M.default(items, opts)
+function M.native(items, opts)
   local options = { prompt = opts.title }
   local function on_choice(item, _)
     if item then
@@ -22,8 +22,8 @@ end
 function M.telescope(items, opts)
   local telescope = pcall(require, "telescope")
   if not telescope then
-    utils.log("Telescope is not installed, defaulting to vim.ui.select picker.")
-    return M.default(items)
+    utils.log("Telescope is not installed, defaulting to native vim.ui.select picker.")
+    return M.native(items)
   end
 
   local actions = require("telescope.actions")
@@ -53,8 +53,8 @@ end
 
 function M.__index(_, k)
   if k ~= nil then
-    utils.log(k .. " is not a valid picker, defaulting to vim.ui.select picker.")
-    return M.default
+    utils.log(k .. " is not a valid picker, defaulting to native vim.ui.select picker.")
+    return M.native
   end
 end
 


### PR DESCRIPTION
Renamed the default_picker "default" to "native" to prevent internal development confusion when working with pickers.