### PR TITLE
feat(logs)!: config minimum log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ require("urlview").setup({
   unique = true,
   -- Ensure links shown in the picker are sorted alphabetically
   sorted = true,
-  -- Logs user warnings (recommended for error detection)
-  debug = true,
+  -- Minimum log level (recommended at least `vim.log.levels.WARN` for error detection warnings)
+  debug_level_min = vim.log.levels.INFO,
   -- Keymaps for jumping to previous / next URL in buffer
   jump = {
     prev = "[u",

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ require("urlview").setup({
   -- Ensure links shown in the picker are sorted alphabetically
   sorted = true,
   -- Minimum log level (recommended at least `vim.log.levels.WARN` for error detection warnings)
-  debug_level_min = vim.log.levels.INFO,
+  log_level_min = vim.log.levels.INFO,
   -- Keymaps for jumping to previous / next URL in buffer
   jump = {
     prev = "[u",

--- a/lua/urlview/actions.lua
+++ b/lua/urlview/actions.lua
@@ -10,10 +10,13 @@ local function shell_exec(cmd, raw_url)
     -- NOTE: `vim.fn.system` shellescapes arguments
     local err = vim.fn.system({ cmd, raw_url })
     if err ~= "" then
-      utils.log(string.format("Could not navigate link with `%s`:\n%s", cmd, err))
+      utils.log(string.format("Could not navigate link with `%s`:\n%s", cmd, err), vim.log.levels.ERROR)
     end
   else
-    utils.log(string.format("Cannot use %s to navigate links", cmd), vim.log.levels.DEBUG)
+    utils.log(
+      string.format("Cannot use command `%s` to navigate links (either empty or non-executable)", cmd),
+      vim.log.levels.ERROR
+    )
   end
 end
 
@@ -37,7 +40,10 @@ function M.system(raw_url)
   elseif os == "Linux" or os == "FreeBSD" then -- Linux and FreeBSD
     shell_exec("xdg-open", raw_url)
   else
-    utils.log("Unsupported operating system for `system` action. Please raise a GitHub issue for " .. os)
+    utils.log(
+      "Unsupported operating system for `system` action. Please raise a GitHub issue for " .. os,
+      vim.log.levels.WARN
+    )
   end
 end
 
@@ -45,7 +51,7 @@ end
 ---@param raw_url string @unescaped URL
 function M.clipboard(raw_url)
   vim.api.nvim_command(string.format("let @+ = '%s'", raw_url))
-  utils.log(string.format("URL %s copied to clipboard", raw_url))
+  utils.log(string.format("URL %s copied to clipboard", raw_url), vim.log.levels.INFO)
 end
 
 return setmetatable(M, {

--- a/lua/urlview/config.lua
+++ b/lua/urlview/config.lua
@@ -26,7 +26,7 @@ local default_config = {
   -- Ensure links shown in the picker are sorted alphabetically
   sorted = true,
   -- Minimum log level (recommended at least `vim.log.levels.WARN` for error detection warnings)
-  debug_level_min = vim.log.levels.INFO,
+  log_level_min = vim.log.levels.INFO,
   -- Keymaps for jumping to previous / next URL in buffer
   jump = {
     prev = "[u",

--- a/lua/urlview/config.lua
+++ b/lua/urlview/config.lua
@@ -25,8 +25,8 @@ local default_config = {
   unique = true,
   -- Ensure links shown in the picker are sorted alphabetically
   sorted = true,
-  -- Logs user warnings (recommended for error detection)
-  debug = true,
+  -- Minimum log level (recommended at least `vim.log.levels.WARN` for error detection warnings)
+  debug_level_min = vim.log.levels.INFO,
   -- Keymaps for jumping to previous / next URL in buffer
   jump = {
     prev = "[u",

--- a/lua/urlview/init.lua
+++ b/lua/urlview/init.lua
@@ -67,12 +67,13 @@ function M.command_search(...)
 end
 
 local function check_breaking()
-  if config.navigate_method then
-    utils.log(
-      [[`config.navigate_method` has been deprecated for `config.default_action`
-    Please see https://github.com/axieax/urlview.nvim/issues/37#issuecomment-1251246520]],
-      vim.log.levels.WARN
-    )
+  if config.navigate_method ~= nil then
+    utils.log([[`config.navigate_method` has been deprecated for `config.default_action`
+    Please see https://github.com/axieax/urlview.nvim/issues/37#issuecomment-1251246520]])
+  end
+  if config.debug ~= nil then
+    utils.log([[`config.debug` has been deprecated for `config.log_level_min`
+    Please see https://github.com/axieax/urlview.nvim/issues/37#issuecomment-1257113527]])
   end
 end
 

--- a/lua/urlview/init.lua
+++ b/lua/urlview/init.lua
@@ -33,7 +33,7 @@ function M.search(ctx, opts)
     end
     pickers[picker](links, opts)
   else
-    utils.log("No links found in context " .. ctx)
+    utils.log("No links found in context " .. ctx, vim.log.levels.INFO)
   end
 end
 
@@ -68,8 +68,11 @@ end
 
 local function check_breaking()
   if config.navigate_method then
-    utils.log([[`config.navigate_method` has been deprecated for `config.default_action`
-    Please see https://github.com/axieax/urlview.nvim/issues/37#issuecomment-1251246520]])
+    utils.log(
+      [[`config.navigate_method` has been deprecated for `config.default_action`
+    Please see https://github.com/axieax/urlview.nvim/issues/37#issuecomment-1251246520]],
+      vim.log.levels.WARN
+    )
   end
 end
 

--- a/lua/urlview/jump.lua
+++ b/lua/urlview/jump.lua
@@ -113,7 +113,7 @@ local function goto_url(reversed)
     local winnr = vim.api.nvim_get_current_win()
     local pos = M.find_url(winnr, reversed)
     if not pos then
-      utils.log(string.format("Cannot find any %s URLs in buffer", direction))
+      utils.log(string.format("Cannot find any %s URLs in buffer", direction), vim.log.levels.INFO)
       return
     end
 
@@ -121,7 +121,10 @@ local function goto_url(reversed)
       vim.cmd("normal! m'") -- add to jump list
       vim.api.nvim_win_set_cursor(winnr, pos)
     else
-      utils.log(string.format("The %s URL was found in window number %s, which is no longer valid", direction, winnr))
+      utils.log(
+        string.format("The %s URL was found in window number %s, which is no longer valid", direction, winnr),
+        vim.log.levels.WARN
+      )
     end
   end
 end
@@ -136,7 +139,7 @@ M.prev_url = goto_url(true)
 ---@param jump_opts table
 function M.register_mappings(jump_opts)
   if type(jump_opts) ~= "table" then
-    utils.log("Invalid type for option `jump` (expected: table with prev_url and next_url keys)")
+    utils.log("Invalid type for option `jump` (expected: table with prev_url and next_url keys)", vim.log.levels.WARN)
   else
     if jump_opts.prev ~= "" then
       utils.keymap(

--- a/lua/urlview/pickers.lua
+++ b/lua/urlview/pickers.lua
@@ -22,7 +22,7 @@ end
 function M.telescope(items, opts)
   local telescope = pcall(require, "telescope")
   if not telescope then
-    utils.log("Telescope is not installed, defaulting to native vim.ui.select picker.")
+    utils.log("Telescope is not installed, defaulting to native vim.ui.select picker.", vim.log.levels.INFO)
     return M.native(items, opts)
   end
 
@@ -57,7 +57,7 @@ return setmetatable(M, {
   -- use default `vim.ui.select` when provided an invalid picker
   __index = function(_, k)
     if k ~= nil then
-      utils.log(k .. " is not a valid picker, defaulting to native vim.ui.select picker.")
+      utils.log(k .. " is not a valid picker, defaulting to native vim.ui.select picker.", vim.log.levels.INFO)
       return M.native
     end
   end,

--- a/lua/urlview/search/helpers.lua
+++ b/lua/urlview/search/helpers.lua
@@ -7,7 +7,11 @@ local utils = require("urlview.utils")
 ---@param bufnr number (optional)
 ---@return string @content of buffer
 function M.get_buffer_content(bufnr)
-  bufnr = M.fallback(bufnr, 0)
+  bufnr = utils.fallback(bufnr, 0)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    utils.log(string.format("Invalid buffer number provided: %s", bufnr), vim.log.levels.ERROR)
+    return ""
+  end
   return table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
 end
 
@@ -17,7 +21,7 @@ end
 function M.read_file(filepath)
   local f, err = io.open(vim.fn.expand(filepath), "r")
   if f == nil then
-    M.log(err, vim.log.levels.ERROR)
+    utils.log(err, vim.log.levels.ERROR)
     return ""
   end
   local content = f:read("*all")

--- a/lua/urlview/search/helpers.lua
+++ b/lua/urlview/search/helpers.lua
@@ -3,6 +3,28 @@ local M = {}
 local constants = require("urlview.config")._constants
 local utils = require("urlview.utils")
 
+--- Extracts content from a given buffer
+---@param bufnr number (optional)
+---@return string @content of buffer
+function M.get_buffer_content(bufnr)
+  bufnr = M.fallback(bufnr, 0)
+  return table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
+end
+
+--- Extracts content from a given file
+---@param filepath string @path to file
+---@return string @content of file (or empty string if file cannot be open)
+function M.read_file(filepath)
+  local f, err = io.open(vim.fn.expand(filepath), "r")
+  if f == nil then
+    M.log(err, vim.log.levels.ERROR)
+    return ""
+  end
+  local content = f:read("*all")
+  f:close()
+  return content
+end
+
 --- Extracts urls from the given content
 ---@param content string
 ---@return table (list) of strings (extracted links)
@@ -38,6 +60,19 @@ function M.content(content)
   return links
 end
 
+--- Extract @captures from @content and display them as @formats
+---@param content string @content to extract from
+---@param capture string @capture pattern to extract
+---@param format string @format pattern to display
+---@return table @list of extracted links
+function M.extract_pattern(content, capture, format)
+  local captures = {}
+  for c in content:gmatch(capture) do
+    table.insert(captures, string.format(format, c))
+  end
+  return captures
+end
+
 --- Generates a simple search function from a template table
 ---@param patterns table (map) with `capture` and `format` keys
 ---@return function|nil
@@ -47,8 +82,8 @@ local function default_custom_generator(patterns)
   end
 
   return function(opts)
-    local content = opts.content or utils.get_buffer_content(opts.bufnr)
-    return utils.extract_pattern(content, patterns.capture, patterns.format)
+    local content = opts.content or M.get_buffer_content(opts.bufnr)
+    return M.extract_pattern(content, patterns.capture, patterns.format)
   end
 end
 
@@ -68,24 +103,17 @@ function M.register_custom_searches(searchers)
           string.format(
             "Unable to register custom searcher %s: please ensure that the table has 'capture' and 'format' fields",
             source
-          )
+          ),
+          vim.log.levels.WARN
         )
       end
     else
       utils.log(
-        string.format("Unable to register custom searcher %s: invalid type (not a function or map table)", source)
+        string.format("Unable to register custom searcher %s: invalid type (not a function or map table)", source),
+        vim.log.levels.WARN
       )
     end
   end
-end
-
---- Finds the remote url of a local Git respository
----@param path string @path to a local Git repository
----@return string|nil @remote url of the repository if found, otherwise nil
-function M.git_remote_url(path)
-  path = vim.fn.shellescape(path)
-  local url = vim.fn.system(string.format("cd %s && git remote get-url origin", path))
-  return utils.ternary(vim.v.shell_error == 0, url:gsub("%.git\n$", ""), nil)
 end
 
 return M

--- a/lua/urlview/search/init.lua
+++ b/lua/urlview/search/init.lua
@@ -9,7 +9,7 @@ local search_helpers = require("urlview.search.helpers")
 ---@param opts table (map, optional)
 ---@return table (list) of strings (extracted links)
 function M.buffer(opts)
-  local content = utils.get_buffer_content(opts.bufnr)
+  local content = search_helpers.get_buffer_content(opts.bufnr)
   return search_helpers.content(content)
 end
 
@@ -17,7 +17,7 @@ end
 ---@param opts table (map, optional)
 ---@return table (list) of strings (extracted links)
 function M.file(opts)
-  local content = utils.fallback(utils.read_file(opts.filepath), "")
+  local content = search_helpers.read_file(opts.filepath)
   return search_helpers.content(content)
 end
 
@@ -49,7 +49,7 @@ return setmetatable(M, {
   -- error check for invalid searcher (still allow function calls, but return nil)
   __index = function(_, k)
     if k ~= nil then
-      utils.log("Cannot search context " .. k)
+      utils.log("Cannot search context " .. k, vim.log.levels.WARN)
       return function()
         return nil
       end

--- a/lua/urlview/search/init.lua
+++ b/lua/urlview/search/init.lua
@@ -6,7 +6,7 @@ local search_helpers = require("urlview.search.helpers")
 -- NOTE: make sure to add accepted params for `opts` to `urlview.search.validation` as well if needed
 
 --- Extracts urls from the current buffer or a given buffer
----@param opts table (map, optional)
+---@param opts table (map)
 ---@return table (list) of strings (extracted links)
 function M.buffer(opts)
   local content = search_helpers.get_buffer_content(opts.bufnr)
@@ -14,7 +14,7 @@ function M.buffer(opts)
 end
 
 --- Extracts urls from a given file
----@param opts table (map, optional)
+---@param opts table (map)
 ---@return table (list) of strings (extracted links)
 function M.file(opts)
   local content = search_helpers.read_file(opts.filepath)

--- a/lua/urlview/search/init.lua
+++ b/lua/urlview/search/init.lua
@@ -46,12 +46,12 @@ function M.vimplug()
 end
 
 return setmetatable(M, {
-  -- error check for invalid searcher (still allow function calls, but return nil)
+  -- error check for invalid searcher (still allow function calls, but return empty table)
   __index = function(_, k)
     if k ~= nil then
       utils.log("Cannot search context " .. k, vim.log.levels.WARN)
       return function()
-        return nil
+        return {}
       end
     end
   end,

--- a/lua/urlview/search/validation.lua
+++ b/lua/urlview/search/validation.lua
@@ -37,11 +37,14 @@ local function verify_or_accept(opts, accepted_opts)
     local expected_type, is_optional = unpack(expected_v)
     local user_option = opts[expected_key]
     if not is_optional and user_option == nil then
-      utils.log(string.format("Missing required option `%s`", expected_key))
+      utils.log(string.format("Missing required option `%s`", expected_key), vim.log.levels.WARN)
     elseif user_option ~= nil then
       new_opts[expected_key] = validate_type(user_option, expected_type)
       if new_opts[expected_key] == nil then
-        utils.log(string.format("Invalid type for option `%s` (expected: %s)", expected_key, expected_type))
+        utils.log(
+          string.format("Invalid type for option `%s` (expected: %s)", expected_key, expected_type),
+          vim.log.levels.WARN
+        )
       end
     end
   end

--- a/lua/urlview/utils.lua
+++ b/lua/urlview/utils.lua
@@ -3,41 +3,6 @@ local M = {}
 local config = require("urlview.config")
 local constants = config._constants
 
---- Extracts content from a given buffer
----@param bufnr number (optional)
----@return string @content of buffer
-function M.get_buffer_content(bufnr)
-  bufnr = M.fallback(bufnr, 0)
-  return table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
-end
-
---- Extracts content from a given file
----@param filepath string @path to file
----@return string|nil @content of file (or nil if file cannot be open)
-function M.read_file(filepath)
-  local f = io.open(vim.fn.expand(filepath), "r")
-  if f == nil then
-    M.log("Could not open file: " .. filepath)
-    return nil
-  end
-  local content = f:read("*all")
-  f:close()
-  return content
-end
-
---- Extract @captures from @content and display them as @formats
----@param content string @content to extract from
----@param capture string @capture pattern to extract
----@param format string @format pattern to display
----@return table @list of extracted links
-function M.extract_pattern(content, capture, format)
-  local captures = {}
-  for c in content:gmatch(capture) do
-    table.insert(captures, string.format(format, c))
-  end
-  return captures
-end
-
 --- Prepare links before being displayed
 ---@param links table @list of extracted links
 ---@param opts table @Optional options
@@ -97,7 +62,7 @@ end
 ---@param level integer|nil @log level, defaults to "warning"
 function M.log(message, level)
   level = M.fallback(level, vim.log.levels.WARN)
-  if config.debug then
+  if level >= config.debug_level_min then
     vim.notify("[urlview.nvim] " .. message, level)
   end
 end

--- a/lua/urlview/utils.lua
+++ b/lua/urlview/utils.lua
@@ -62,7 +62,7 @@ end
 ---@param level integer|nil @log level, defaults to "warning"
 function M.log(message, level)
   level = M.fallback(level, vim.log.levels.WARN)
-  if level >= config.debug_level_min then
+  if level >= config.log_level_min then
     vim.notify("[urlview.nvim] " .. message, level)
   end
 end


### PR DESCRIPTION
This PR enables users to specify a minimum log level for this plugin's logger. This allows them to mute less important logs if so desired.

- [x] Refactor search-related utilities to search_helpers module (unrelated)
- [x] !Update `config.debug` for `config.log_level_min` (https://github.com/axieax/urlview.nvim/issues/37#issuecomment-1257113527)