### PR TITLE
Telescope: Allow multiple selection

### DIFF
--- a/lua/urlview/pickers.lua
+++ b/lua/urlview/pickers.lua
@@ -41,10 +41,16 @@ function M.telescope(items, opts)
       sorter = conf.generic_sorter(opts),
       attach_mappings = function(prompt_bufnr, _)
         actions.select_default:replace(function()
-          local selection = action_state.get_selected_entry()
+          local picker = action_state.get_current_picker(prompt_bufnr)
+          local multi = picker:get_multi_selection()
+          local single = picker:get_selection()
           actions.close(prompt_bufnr)
-          if selection[1] then
-            opts.action(selection[1])
+          if #multi > 0 then
+            for _, entry in ipairs(multi) do
+              opts.action(entry[1])
+            end
+          elseif single[1] then
+            opts.action(single[1])
           end
         end)
         return true


### PR DESCRIPTION
Pressing tab over the current menu item adds it to the list of selected URL's, but currently the action only runs for the first element of that list.

This is taken from  [here](https://github.com/nvim-telescope/telescope.nvim/issues/1048#issuecomment-1140280174).
I don't know if there is a better way to do it.