### PR TITLE
fix(netrw): ensure netrw fallback works

### DIFF
--- a/lua/urlview/actions.lua
+++ b/lua/urlview/actions.lua
@@ -31,7 +31,7 @@ end
 function M.netrw(raw_url)
   local url = vim.fn.shellescape(raw_url)
   local ok, err = pcall(vim.cmd, string.format("call netrw#BrowseX(%s, netrw#CheckIfRemote(%s))", url, url))
-  if not ok and vim.startswith(err, "Vim(call):E117: Unknown function") then
+  if not ok and string.find(err, "Vim(call):E117: Unknown function", 1, true) then
     -- lazily use system action if netrw is disabled
     M.system(raw_url)
   end

--- a/tests/urlview/netrw_spec.lua
+++ b/tests/urlview/netrw_spec.lua
@@ -1,0 +1,26 @@
+local urlview = require("urlview")
+local actions = require("urlview.actions")
+local stub = require("luassert.stub")
+local netrw_action = require("urlview.actions").netrw
+
+describe("M.netrw fallback when netrw is disabled", function()
+  before_each(function()
+    -- disable netrw
+    vim.g.loaded_netrw = 1
+    vim.g.loaded_netrwPlugin = 1
+
+    vim.cmd("enew")
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      "Here is a link: https://example.com",
+    })
+    urlview.setup({})
+  end)
+
+  it("calls the system fallback", function()
+    stub(actions, "system")
+
+    netrw_action("https://example.com")
+
+    assert.stub(actions.system).was.called_with("https://example.com")
+  end)
+end)


### PR DESCRIPTION
neovim 0.9.0 replaced nvim_exec with nvim_exec2[1] which changed the error message string:

nvim < 0.9.0: Vim(call):E117: Unknown function: netrw#CheckIfRemote
nvim >=0.9.0: vim/_editor.lua:0: nvim_exec2(): Vim(call):E117: Unknown function: netrw#CheckIfRemote

Because the match with startswith now fails, the fallback is not executed and nothing happens while attempting to open the URL.

Fix it by searching for the error message anywhere in the string.

[1] https://github.com/neovim/neovim/pull/19032